### PR TITLE
Comment highlighting doesn't work

### DIFF
--- a/Syntaxes/Smarty.tmLanguage
+++ b/Syntaxes/Smarty.tmLanguage
@@ -5,7 +5,6 @@
 	<key>fileTypes</key>
 	<array>
 		<string>tpl</string>
-		<string>tpl.php</string>
 	</array>
 	<key>foldingStartMarker</key>
 	<string>\{%</string>
@@ -100,15 +99,12 @@
 				</dict>
 			</array>
 		</dict>
-		<!--
 		<dict>
 			<key>match</key>
 			<string>(!=|!|&lt;=|&gt;=|&lt;|(?&lt;!-)&gt;|===|==|%|&amp;&amp;|\|\|)|\b(and|or|eq|neq|ne|gte|gt|ge|lte|lt|le|not|mod)\b</string>
 			<key>name</key>
 			<string>keyword.operator.smarty</string>
 		</dict>
-		-->
-
 		<dict>
 			<key>match</key>
 			<string>\b(TRUE|FALSE|true|false)\b</string>


### PR DESCRIPTION
I'm not sure about the original regex but standard comment syntax, "{\* comment *}", wasn't properly highlighted. My changes fix this.
