### PR TITLE
Include text.html.basic broken

### DIFF
--- a/Syntaxes/Smarty.tmLanguage
+++ b/Syntaxes/Smarty.tmLanguage
@@ -5,7 +5,6 @@
 	<key>fileTypes</key>
 	<array>
 		<string>tpl</string>
-		<string>tpl.php</string>
 	</array>
 	<key>foldingStartMarker</key>
 	<string>\{%</string>
@@ -17,7 +16,7 @@
 	<array>
 		<dict>
 			<key>begin</key>
-			<string>\{\*</string>
+			<string>(\{%)\*</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -27,7 +26,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>\*\}</string>
+			<string>\*(%\})</string>
 			<key>name</key>
 			<string>comment.block.smarty</string>
 			<key>patterns</key>
@@ -100,15 +99,6 @@
 				</dict>
 			</array>
 		</dict>
-		<!--
-		<dict>
-			<key>match</key>
-			<string>(!=|!|&lt;=|&gt;=|&lt;|(?&lt;!-)&gt;|===|==|%|&amp;&amp;|\|\|)|\b(and|or|eq|neq|ne|gte|gt|ge|lte|lt|le|not|mod)\b</string>
-			<key>name</key>
-			<string>keyword.operator.smarty</string>
-		</dict>
-		-->
-
 		<dict>
 			<key>match</key>
 			<string>\b(TRUE|FALSE|true|false)\b</string>


### PR DESCRIPTION
Including the normal HTML syntax definitions doesn't work. I would prefer HTML to look the same wether it is in a PHP, Smarty, or whatever file. I tracked it down to this block. Removing it fixes my problem, but probably removes some other features.
