### PR TITLE
Add `!==` operator to patterns

### DIFF
--- a/Syntaxes/Smarty.JSON-tmLanguage
+++ b/Syntaxes/Smarty.JSON-tmLanguage
@@ -96,7 +96,7 @@
 		"lang": {
 			"patterns": [
 				{
-					"match": "(!=|!|<=|>=|<|>|===|==|%|&&|\\|\\|)|\\b(and|or|eq|neq|ne|gte|gt|ge|lte|lt|le|not|mod)\\b",
+					"match": "(!==|!=|!|<=|>=|<|>|===|==|%|&&|\\|\\|)|\\b(and|or|eq|neq|ne|gte|gt|ge|lte|lt|le|not|mod)\\b",
 					"name": "keyword.operator.smarty"
 				},
 				{

--- a/Syntaxes/Smarty.tmLanguage
+++ b/Syntaxes/Smarty.tmLanguage
@@ -104,7 +104,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>(!=|!|&lt;=|&gt;=|&lt;|&gt;|===|==|%|&amp;&amp;|\|\|)|\b(and|or|eq|neq|ne|gte|gt|ge|lte|lt|le|not|mod)\b</string>
+					<string>(!==|!=|!|&lt;=|&gt;=|&lt;|&gt;|===|==|%|&amp;&amp;|\|\|)|\b(and|or|eq|neq|ne|gte|gt|ge|lte|lt|le|not|mod)\b</string>
 					<key>name</key>
 					<string>keyword.operator.smarty</string>
 				</dict>


### PR DESCRIPTION
Currently only the `!=` in a `!==` gets syntax highlighted.

This does not update the built version of the file, but I'd be happy to build it and update the PR if you'd like.