### PR TITLE
add sublime-syntax for enhanced features in ST3 and easier maintenance

### DIFF
--- a/Syntaxes/Smarty.JSON-tmLanguage
+++ b/Syntaxes/Smarty.JSON-tmLanguage
@@ -108,10 +108,10 @@
 					"name": "keyword.control.smarty"
 				},
 				{
-					"match": "\\b([a-zA-Z]+)=",
+					"match": "\\b([a-zA-Z]+)(=)",
 					"name": "meta.attribute.smarty",
 					"captures": {
-						"0": { "name": "variable.parameter.smarty" }
+						"0": { "name": "variable.parameter.smarty" },
 						"2": { "name": "keyword.operator.assignment.smarty" }
 					},
 				},

--- a/Syntaxes/Smarty.JSON-tmLanguage
+++ b/Syntaxes/Smarty.JSON-tmLanguage
@@ -112,6 +112,7 @@
 					"name": "meta.attribute.smarty",
 					"captures": {
 						"0": { "name": "variable.parameter.smarty" }
+						"2": { "name": "keyword.operator.assignment.smarty" }
 					},
 				},
 				{

--- a/Syntaxes/Smarty.sublime-syntax
+++ b/Syntaxes/Smarty.sublime-syntax
@@ -1,0 +1,96 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/3/syntax.html
+name: Smarty
+file_extensions:
+  - tpl
+scope: text.html.smarty
+
+contexts:
+  main:
+    - match: ''
+      push: scope:text.html.basic
+      with_prototype:
+        - match: '(\{%?)\*'
+          captures:
+            1: punctuation.definition.comment.smarty
+          push:
+            - meta_scope: comment.block.smarty
+            - match: '\*(%?\})'
+              pop: true
+        - match: '(\{%?)'
+          captures:
+            1: punctuation.section.embedded.begin.smarty
+          push:
+            - meta_scope: source.smarty
+            - match: '(%?\})'
+              captures:
+                1: punctuation.section.embedded.end.smarty
+              pop: true
+            - include: strings
+            - include: variables
+            - include: lang
+
+  lang:
+    - match: (!==|!=|!|<=|>=|<|>|===|==|%|&&|\|\|)|\b(and|or|eq|neq|ne|gte|gt|ge|lte|lt|le|not|mod)\b
+      scope: keyword.operator.smarty
+    - match: \b(TRUE|FALSE|true|false)\b
+      scope: constant.language.smarty
+    - match: \b(if|else|elseif|foreach|foreachelse|section|switch|case|break|default)\b
+      scope: keyword.control.smarty
+    - match: '\b([a-zA-Z]+)(=)'
+      scope: meta.attribute.smarty
+      captures:
+        0: variable.parameter.smarty
+        2: keyword.operator.assignment.smarty
+    - match: '\b(capture|config_load|counter|cycle|debug|eval|fetch|include_php|include|insert|literal|math|strip|rdelim|ldelim|assign|constant|block|html_[a-z_]*)\b'
+      scope: support.function.built-in.smarty
+    - match: \|(capitalize|cat|count_characters|count_paragraphs|count_sentences|count_words|date_format|default|escape|indent|lower|nl2br|regex_replace|replace|spacify|string_format|strip_tags|strip|truncate|upper|wordwrap)
+      scope: support.function.variable-modifier.smarty
+
+  strings:
+    - match: "'"
+      captures:
+        0: punctuation.definition.string.begin.smarty
+      push:
+        - meta_scope: string.quoted.single.smarty
+        - match: "'"
+          captures:
+            0: punctuation.definition.string.end.smarty
+          pop: true
+        - match: \\.
+          scope: constant.character.escape.smarty
+    - match: '"'
+      captures:
+        0: punctuation.definition.string.begin.smarty
+      push:
+        - meta_scope: string.quoted.double.smarty
+        - match: '"'
+          captures:
+            0: punctuation.definition.string.end.smarty
+          pop: true
+        - match: \\.
+          scope: constant.character.escape.smarty
+
+  variables:
+    - match: \b(\$)Smarty\.
+      scope: variable.other.global.smarty
+      captures:
+        1: punctuation.definition.variable.smarty
+    - match: '(\$)([a-zA-Z_][a-zA-Z0-9_]*)\b'
+      scope: variable.other.smarty
+      captures:
+        1: punctuation.definition.variable.smarty
+        2: variable.other.smarty
+    - match: '(->)([a-zA-Z_][a-zA-Z0-9_]*)\b'
+      scope: variable.other.smarty
+      captures:
+        1: keyword.operator.smarty
+        2: variable.other.property.smarty
+    - match: '(->)([a-zA-Z_][a-zA-Z0-9_]*)(\().*?(\))'
+      scope: variable.other.smarty
+      captures:
+        1: keyword.operator.smarty
+        2: meta.function-call.object.smarty
+        3: punctuation.definition.variable.smarty
+        4: punctuation.definition.variable.smarty

--- a/Syntaxes/Smarty.tmLanguage
+++ b/Syntaxes/Smarty.tmLanguage
@@ -128,9 +128,14 @@
 							<key>name</key>
 							<string>variable.parameter.smarty</string>
 						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.operator.assignment.smarty</string>
+						</dict>
 					</dict>
 					<key>match</key>
-					<string>\b([a-zA-Z]+)=</string>
+					<string>\b([a-zA-Z]+)(=)</string>
 					<key>name</key>
 					<string>meta.attribute.smarty</string>
 				</dict>

--- a/example.tpl
+++ b/example.tpl
@@ -27,7 +27,7 @@
 {assign var="name" value="value"}
 
 {capture name="name" assign="variable"}
-	<p class="test">Embedded HTML</p>
+	<p class="test {$some_var}">Embedded HTML</p>
 {/capture}
 
 {if isset($name) && not empty($name) and ($name == "string" || $name eq 'string')}


### PR DESCRIPTION
@amitsnyderman I've converted the syntax to the sublime-syntax format supported by Sublime Text 3. Besides the yaml file being a lot easier to work with, it has a bunch more features like `with-prototype`. This allows the syntax to recognize Smarty variables and other expressions inside HTML strings (e.g. `<div class="{$smarty-var}"`), as demonstrated in the updated example file.

Sublime Text 3 will automatically pick up on the new syntax file and will ignore the old tmLanguage file. Sublime Text 2 (for whoever is still holding out with that one) will ignore the new file. So we kan keep them side by side and everyone gets the best version their editor supports. This does mean that the JSON variant is really just a legacy artefact.

PS. If you want, I'd like to have access to the repo to help with addressing issues, perhaps making some other improvements down the line. If you need credentials, I already maintain a bunch of major syntaxes for ST ([LESS](https://packagecontrol.io/packages/LESS), [Sass](https://packagecontrol.io/packages/Sass), [Liquid](https://packagecontrol.io/packages/Liquid)) and in general like to contribute to the syntaxes I use every day.

PPS. Unrelated, but I also committed a change that will highlight the `=` separately. Could spin it off to a separate PR, but 🤷‍♂️ 