### PR TITLE
Fixed issue with interpreting braces

### DIFF
--- a/Syntaxes/Smarty.sublime-syntax
+++ b/Syntaxes/Smarty.sublime-syntax
@@ -18,12 +18,12 @@ contexts:
             - meta_scope: comment.block.smarty
             - match: '\*(%?\})'
               pop: true
-        - match: '(\{%?)'
+        - match: '(\{(?!\s)|\{%\s?)'
           captures:
             1: punctuation.section.embedded.begin.smarty
           push:
             - meta_scope: source.smarty
-            - match: '(%?\})'
+            - match: '(\s%\}|(?!\s)\})'
               captures:
                 1: punctuation.section.embedded.end.smarty
               pop: true


### PR DESCRIPTION
When editing a document with braces in it, this syntax (and the old one too) would think that everything within these braces is Smarty syntax, which is wrong.

So, I have fixed it!

Explicitly defined delimiters:

- `{` and `}`
- `{% ` and ` %}`